### PR TITLE
Fix typing issue to allow compilation with clang/clang++

### DIFF
--- a/src/shf.lock.h
+++ b/src/shf.lock.h
@@ -178,7 +178,7 @@ shf_spin_unlock(SHF_SPIN_LOCK * lock)
 
 union SHF_RW_LOCK_UNION
 {
-    volatile uint32_t as_u64;
+    volatile uint64_t as_u64;
     volatile uint32_t as_u32;
     volatile uint16_t as_u16;
     struct


### PR DESCRIPTION
While attempting to compile with clang, I ran into what looks like a potential error in [shf.lock.h:181](https://github.com/simonhf/sharedhashfile/blob/master/src/shf.lock.h#L181). I got the following error when compiling with clang:

```
In file included from src/main.shf.monitor.c:28:
In file included from src/shf.private.h:29:
src/shf.lock.h:216:81: error: implicit conversion from 'long' to 'uint32_t' (aka 'unsigned int') changes value
      from 4294967296 to 0 [-Werror,-Wconstant-conversion]
  ...tmp                   = __sync_fetch_and_add_8(&lock->lock.as_u64, SHF_RW_LOCK_INC_TICKET_NEXT); /* atom...
                             ~~~~~~~~~~~~~~~~~~~~~~                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/shf.lock.h:210:52: note: expanded from macro 'SHF_RW_LOCK_INC_TICKET_NEXT'
#define SHF_RW_LOCK_INC_TICKET_NEXT               (0x0000000100000000)
                                                   ^~~~~~~~~~~~~~~~~~
```

Commit [f753993](https://github.com/simonhf/sharedhashfile/commit/f75399349db42856f1d7b18cbf8ef9f32f25a4d5) eliminates this error and passes the built-in self-test.

Environment:
```sh
$ clang --version
clang version 6.0.1-9 (tags/RELEASE_601/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.10
DISTRIB_CODENAME=cosmic
DISTRIB_DESCRIPTION="Ubuntu 18.10"
```